### PR TITLE
[Refactor] followServiceImpl, followRepository 리팩토링

### DIFF
--- a/src/main/java/com/example/satto/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/com/example/satto/domain/follow/repository/FollowRepository.java
@@ -3,6 +3,8 @@ package com.example.satto.domain.follow.repository;
 import com.example.satto.domain.follow.entity.Follow;
 import com.example.satto.domain.users.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -23,6 +25,10 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     @Transactional
     void deleteByFollowerId(Users followerId);
     List<Follow> findByFollowingIdStudentIdAndRequest(String studentId, int i);
+
+    // Fetch Join : followRequestList 최적화
+    @Query("SELECT f FROM Follow f JOIN FETCH f.followerId WHERE f.followingId.studentId = :studentId AND f.request = :request")
+    List<Follow> findFollowRequestWithUserByFollowingId(@Param("studentId") String studentId, @Param("request") int request);
 
 //    boolean existsByFollowerIdStudentIdAndFollowingIdStudentId(String followingId, String studentId);
 }

--- a/src/main/java/com/example/satto/domain/follow/service/Impl/FollowServiceImpl.java
+++ b/src/main/java/com/example/satto/domain/follow/service/Impl/FollowServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+
 import java.util.*;
 
 @Service
@@ -46,7 +47,7 @@ public class FollowServiceImpl implements FollowService {
     @Override
     public Map<String, String> followRequestList(String studentId) {
         // 팔로우 요청을 보낸 사람들의 목록을 가져온다.
-        List<Follow> followerRequests = followRepository.findByFollowingIdStudentIdAndRequest(studentId, 1);
+        List<Follow> followerRequests = followRepository.findFollowRequestWithUserByFollowingId(studentId, 1);
         Map<String, String> followRequesters = new HashMap<>();
 
         for (Follow follow : followerRequests) {


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #198 

## 📌 개요
- Follow 엔티티에서 follower, following 필드가 https://github.com/manytoone(fetch = FetchType.LAZY)로 설정되어 있어 
연관된 Users 정보를 실제 접근 시점에 추가 조회를 함

- followRequestList() 등에서 여러 팔로워/팔로잉 정보를 순차적으로 조회할 경우 각 요청마다 별도의 select 쿼리가 발생하여
N+1 문제가 발생함

- 이를 해결하기 위해 Fetch Join을 사용하여 한 번의 쿼리로 연관된 Users 정보를 함께 조회할 수 있도록 리팩토링이 필요

## 🔁 변경 사항
- followServiceImpl 
~~List<Follow> followerRequests = followRepository.findByFollowingIdStudentIdAndRequest(studentId, 1);~~  
List<Follow> followerRequests = followRepository.findFollowRequestWithUserByFollowingId(studentId, 1); // 추가

- followRepository 에 추가 
``` // Fetch Join : followRequestList 최적화Add commentMore actions
    @Query("SELECT f FROM Follow f JOIN FETCH f.followerId WHERE f.followingId.studentId = :studentId AND f.request = :request")
    List<Follow> findFollowRequestWithUserByFollowingId(@Param("studentId") String studentId, @Param("request") int request);
```

 
## Commit Link를 첨부해주세요!
- 5772119bced83139233c0ae51a66bc8b3c2cc6dd

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [ ] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
